### PR TITLE
Language sweep

### DIFF
--- a/Windows/OnboardingWindows/OnboardingApplyChangesToDolphinWindow.axaml
+++ b/Windows/OnboardingWindows/OnboardingApplyChangesToDolphinWindow.axaml
@@ -22,9 +22,9 @@
             <TextBlock TextWrapping="Wrap">Configures Hotkeys for enabling normally un-configured options and disable options that would invalidate a speedrun if used.</TextBlock>
             <TextBlock TextWrapping="Wrap">* Disables Save State Hotkeys (Can be manually reconfigured if wanted for practice).</TextBlock>
             <TextBlock TextWrapping="Wrap">* Disables Emulation Fast Forward.</TextBlock>
-            <TextBlock TextWrapping="Wrap">* Enables Console Reset and Aspect Ratio Toggle, "Pause" Key and F12 Respectively. (Crashes still require shutting down the game.)</TextBlock>
+            <TextBlock TextWrapping="Wrap">* Enables Console Reset and Aspect Ratio Toggle, "Pause" Key and F12 Respectively. (Crashes still require shutting down the game).</TextBlock>
             <CheckBox Name="GameCheckBox">Game Specific Settings</CheckBox>
-            <TextBlock TextWrapping="Wrap">Configures the game to enforce certain emulator settings and provides the Graphics Patch in the form of a Gecko Code. (The patch is only needed to make bloom effects better on dolphin.)</TextBlock>
+            <TextBlock TextWrapping="Wrap">Configures the game to enforce certain emulator settings and provides the Graphics Patch in the form of a Gecko Code. (The patch is only needed to make bloom effects better on Dolphin).</TextBlock>
         </StackPanel>
         <Grid Grid.Row="1" ColumnDefinitions="*, *">
             <Button Grid.Column="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="0,0,5,0" Name="ApplyButton">Apply and Continue</Button>

--- a/Windows/OnboardingWindows/OnboardingSetDolphinPaths.axaml
+++ b/Windows/OnboardingWindows/OnboardingSetDolphinPaths.axaml
@@ -11,7 +11,7 @@
     <Grid RowDefinitions="Auto, Auto" Margin="10">
         <StackPanel Grid.Row="0" Margin="0,0,0,10" Spacing="10">
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">First step is to setup the executable path for Dolphin.</TextBlock>
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">Version 2407 or higher is recommended. older builds can have issues.</TextBlock>
+            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">Version 2409 or newer is recommended. older builds can have issues.</TextBlock>
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">It is highly recommended this is a separate download compared to what is used for other games. Preferably in the same folder as this launcher. This will be further explained in the next step.</TextBlock>
         </StackPanel>
         <Grid Grid.Row="1" ColumnDefinitions="*, *">

--- a/Windows/OnboardingWindows/OnboardingSetDolphinPathsLinux.axaml
+++ b/Windows/OnboardingWindows/OnboardingSetDolphinPathsLinux.axaml
@@ -11,9 +11,9 @@
     <Grid RowDefinitions="Auto, *" Margin="10">
         <StackPanel Grid.Row="0" Margin="0,0,0,10" Spacing="10">
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">First step is to setup the executable path for Dolphin.</TextBlock>
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">Version 2407 or higher is recommended. older builds can have issues.</TextBlock>
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">For Linux, the Flatpak version is recommended for it's ease of setup and configuration. You could also use a native executable if you have one ready for use. This program assumes Flatpak is already configured if selected. Native assumes the typical path for a package download.</TextBlock>
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">The next steps will allow changing configuration settings, but keep in mind these changes will apply for all games played with the picked dolphin instance.</TextBlock>
+            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">Version 2409 or newer is recommended. Older builds can have issues.</TextBlock>
+            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">For Linux, the Flatpak version is recommended for it's ease of setup and configuration. You could also use a native executable if you have one ready for use. If you select Flatpak, this program assumes you have already installed Flatpak and the dolphin-emu flatpak. Native assumes you have used your package manager to install dolphin-emu in /usr/bin.</TextBlock>
+            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">The next steps will allow changing configuration settings, but keep in mind these changes will apply for all games played with the picked Dolphin instance.</TextBlock>
         </StackPanel>
         <Grid Grid.Row="1" ColumnDefinitions="*, *, *, *">
             <Button Grid.Column="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Height="48" Margin="0,0,5,0" Name="SetFlatpakPathButton">


### PR DESCRIPTION
* Unify casing (ex dolphin -> Dolphin)
* Follow en standard on parenthesis sentences having punctuation at the end of the ): `).`
* clarify Linux Native install, 
* or higher -> or newer
* Bump recommended to 2409