### PR TITLE
Make QuickLaunchDolphin onboarding step multi-phase

### DIFF
--- a/Windows/OnboardingWindows/OnboardingApplyChangesToDolphinWindow.axaml
+++ b/Windows/OnboardingWindows/OnboardingApplyChangesToDolphinWindow.axaml
@@ -15,8 +15,8 @@
             <CheckBox Name="CoreCheckBox">Core Settings Adjustments</CheckBox>
             <TextBlock TextWrapping="Wrap">The following adjustments allow for better performance and allowing a graphics patch.</TextBlock>
             <CheckBox Name="GraphicsCheckBox">Graphics Hacks</CheckBox>
-            <TextBlock TextWrapping="Wrap">Turns on most Graphics Hacks to help with performance</TextBlock>
-            <TextBlock TextWrapping="Wrap">Custom Textures are turned on for graphics patches and support for Custom Color Shadow</TextBlock>
+            <TextBlock TextWrapping="Wrap">Turns on most Graphics Hacks to help with performance.</TextBlock>
+            <TextBlock TextWrapping="Wrap">Custom Textures are turned on for graphics patches and support for Custom Color Shadow.</TextBlock>
             <TextBlock TextWrapping="Wrap">Custom Textures for fixing defects in UI displays at higher internal resolutions will also be added.</TextBlock>
             <CheckBox Name="HotkeyCheckBox">Keyboard Hotkeys</CheckBox>
             <TextBlock TextWrapping="Wrap">Configures Hotkeys for enabling normally un-configured options and disable options that would invalidate a speedrun if used.</TextBlock>

--- a/Windows/OnboardingWindows/OnboardingCompleteWindow.axaml
+++ b/Windows/OnboardingWindows/OnboardingCompleteWindow.axaml
@@ -12,7 +12,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,5" Spacing="10">
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">You should be all set now!</TextBlock>
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">Time to make the ROM and begin playing the game!</TextBlock>
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">You also may need to make manual adjustments within dolphin for general graphics and controller settings.</TextBlock>
+            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">You also may need to make manual adjustments within Dolphin for general graphics and controller settings.</TextBlock>
             <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">You can make adjustments to some of these settings in the settings menu or re-run this setup process if needed.</TextBlock>
         </StackPanel>
         <Button Grid.Row="1" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="0,5,5,5" Name="OpenDolphinButton">Open Dolphin</Button>

--- a/Windows/OnboardingWindows/OnboardingQuickLaunchDolphin.axaml
+++ b/Windows/OnboardingWindows/OnboardingQuickLaunchDolphin.axaml
@@ -10,7 +10,7 @@
         WindowStartupLocation="CenterOwner">
     <Grid RowDefinitions="Auto, Auto" Margin="10">
         <StackPanel Grid.Row="0" Margin="0,0,0,10" Spacing="10">
-            <TextBlock HorizontalAlignment="Center" TextWrapping="Wrap">To ensure configuration files are available for the next step. We'll need to launch Dolphin to allow it to generate them.  You can close it shortly after it opens to continue with the next step.</TextBlock>
+            <TextBlock Name="QuickLaunchDolphinStepsTextBlock" HorizontalAlignment="Center" TextWrapping="Wrap">To ensure configuration files are available for the next step, Dolphin will be launched. Press Continue to launch Dolphin.</TextBlock>
         </StackPanel>
         <Grid Grid.Row="1" ColumnDefinitions="*, *">
             <Button Grid.Column="0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="0,0,5,0" Name="ContinueButton">Continue</Button>

--- a/Windows/OnboardingWindows/OnboardingQuickLaunchDolphin.axaml.cs
+++ b/Windows/OnboardingWindows/OnboardingQuickLaunchDolphin.axaml.cs
@@ -1,14 +1,13 @@
 using System;
-using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Markup.Xaml;
 using ShadowSXLauncher.Classes;
 
 namespace ShadowSXLauncher.Windows.OnboardingWindows;
 
 public partial class OnboardingQuickLaunchDolphin : OnboardingWindow
 {
+
+    private int continueTimesPressed = 0;
     public OnboardingQuickLaunchDolphin() : base()
     {
         InitializeComponent();
@@ -23,7 +22,13 @@ public partial class OnboardingQuickLaunchDolphin : OnboardingWindow
 
     private void ContinueButtonOnClick(object? sender, RoutedEventArgs e)
     {
-        CommonUtils.LaunchDolphin(true);
+        if (continueTimesPressed == 0)
+        {
+            _ = CommonUtils.LaunchDolphin(true);
+            QuickLaunchDolphinStepsTextBlock.Text = $"Dolphin has been launched successfully.{Environment.NewLine}You need to close Dolphin before you continue.";
+            continueTimesPressed++;
+            return;
+        }
         SetOnboardingPage(4);
     }
     


### PR DESCRIPTION
* Make QuickLaunchDolphin onboarding step multi-phase, and reword for simplicity.
* Add missing punctuation and one instance of lowercase 'dolphin'

We want this because if the user does not close Dolphin and continues the configuration step, it may get overwritten when Dolphin is closed.