### PR TITLE
Fix patching on Windows

### DIFF
--- a/Windows/MainWindow.axaml.cs
+++ b/Windows/MainWindow.axaml.cs
@@ -231,7 +231,7 @@ public partial class MainWindow : Window
             {
                 var processResult = new Process();
                 processResult.StartInfo.FileName = xdeltaBinPath;
-                processResult.StartInfo.Arguments = $"-v -d -s {baseIdLocation} {vcdiffPath} {patchedRomDestination}";
+                processResult.StartInfo.Arguments = $"-v -d -s \"{baseIdLocation}\" \"{vcdiffPath}\" \"{patchedRomDestination}\"";
                 processResult.StartInfo.RedirectStandardOutput = true;
                 processResult.Start();
                 


### PR DESCRIPTION
Add quotes to paths
* Tested working on Linux
path test : `/home/user/Documents/asaasd asdasd a/4 54  a/GU 2 1PE8i .iso"
* Tested working on Windows
path test: "C:\Users\user\Documents\am 9nm 10a 0 \l a \GU 2 1PE8i .iso"
